### PR TITLE
fix:link值错位

### DIFF
--- a/packages/yugioh-card/src/yugioh-card/index.js
+++ b/packages/yugioh-card/src/yugioh-card/index.js
@@ -624,7 +624,7 @@ export class YugiohCard extends Card {
     });
 
     const linkText = this.data.language === 'astral' ? numberToFull(this.data.arrowList.length) : this.data.arrowList.length;
-    const linkLeft = this.data.language === 'astral' ? 1279 : 1220;
+    const linkLeft = this.data.language === 'astral' ? 1279 : 1280;
     link.set({
       text: linkText,
       fontFamily: this.data.language === 'astral' ? 'ygo-astral, serif' : 'ygo-link, serif',


### PR DESCRIPTION
在commit 6fd0ba9中引入

普通字体时的scaleX是1.3，所以Text右侧坐标是1280而不是1220