### PR TITLE
fix drawCopyright (fix blank below the image)

### DIFF
--- a/packages/yugioh-card/src/yugioh-card/index.js
+++ b/packages/yugioh-card/src/yugioh-card/index.js
@@ -662,6 +662,7 @@ export class YugiohCard extends Card {
       url: copyrightUrl,
       x: this.cardWidth - 141,
       y: 1936,
+      height: this.data.copyright ? null : 0,
       around: { type: 'percent', x: 1, y: 0 },
       visible: this.data.copyright,
       zIndex: 30,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/79d0afcf-f40e-4a6f-add8-83b78a6695b7)

修复前，如果没有设置copyright，对应位置似乎会加载一个很高的空白图片，撑大了整个画布，在底部出现空白